### PR TITLE
Fix 429 errors by caching SAS token and matching official app's requests

### DIFF
--- a/drivers/ac/driver.js
+++ b/drivers/ac/driver.js
@@ -39,16 +39,33 @@ class ACDriver extends Driver {
     devices.forEach(device => device.setEnergyIntervalTimer());
   }
 
-  async initializeAmqp() {
-    const token = await this.httpAPI.getSASToken(this.deviceId);
-    if (!this.amqpAPI) {
-      this.amqpAPI = new AmqpApi(token, this);
-    } else {
-      this.amqpAPI.setToken(token);
+  async initializeAmqp(retryCount = 0) {
+    try {
+      const token = await this.httpAPI.getSASToken(this.deviceId);
+      if (!this.amqpAPI) {
+        this.amqpAPI = new AmqpApi(token, this);
+      } else {
+        this.amqpAPI.setToken(token);
+      }
+    } catch (ex) {
+      const maxRetries = 5;
+      if (retryCount >= maxRetries) {
+        this.error(`initializeAmqp failed after ${maxRetries} retries: ${ex.message}`);
+        return;
+      }
+      // exponential backoff (1, 2, 4, 8, 16 minutes) so a 429 doesn't
+      // immediately trigger another request
+      const delay = 2 ** retryCount * 60 * 1000;
+      this.log(`initializeAmqp failed (${ex.message}), retrying in ${delay / 1000}s`);
+      this.homey.setTimeout(() => this.initializeAmqp(retryCount + 1), delay);
     }
   }
 
   async onPair(session) {
+    this.log('Pairing session started');
+    session.setHandler('showView', async viewId => {
+      this.log(`Pairing: showing view '${viewId}'`);
+    });
     session.setHandler('login', async data => {
       return this.login(data.username, data.password);
     });
@@ -65,12 +82,21 @@ class ACDriver extends Driver {
   }
 
   async login(username, password) {
+    this.log(`Login attempt for username: ${username}`);
+
     // save the username and password
     this.homey.settings.set(Constants.SettingUserName, username);
     this.homey.settings.set(Constants.SettingPassword, password);
 
-    const resobj = await this.httpAPI.login(username, password);
+    let resobj;
+    try {
+      resobj = await this.httpAPI.login(username, password, this.deviceId);
+    } catch (ex) {
+      this.error(`Login failed: ${ex.message}`);
+      throw ex;
+    }
     if (resobj.IsSuccess) {
+      this.log('Login successful');
       this.initializeAmqp();
     }
     // return true to continue adding the device if the login succeeded

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -3,6 +3,8 @@ exports.DOMAIN = 'toshiba_ac';
 
 exports.BASE_URL = 'https://mobileapi.toshibahomeaccontrols.com';
 exports.LOGIN_PATH = '/api/Consumer/Login';
+// static client identifier sent by the official Toshiba app on login
+exports.BRAND_ID = '39635025-5bd1-45bd-af8b-75e71cc90467';
 exports.DEVICE_PATH = '/api/AC/GetRegisteredACByUniqueId';
 exports.MAPPING_PATH = '/api/AC/GetConsumerACMapping';
 exports.STATUS_PATH = '/api/AC/GetCurrentACState';
@@ -97,6 +99,8 @@ exports.SettingTokenInformation = 'TokenInformation';
 exports.StoredValueState = 'state';
 exports.StoredCapabilityTargetACMode = 'target_ac_mode';
 exports.StoredCapabilityTargetSwingMode = 'target_swing_mode';
+exports.SettingSasToken = 'SasToken';
+exports.SettingSasTokenExpiry = 'SasTokenExpiry';
 exports.StoredValuesMeritA = 'ValuesMeritA';
 exports.StoredValuesMeritB = 'ValuesMeritB';
 exports.StoredEnergyPreviousHourEnergy = 'EnergyPreviousHourEnergy';

--- a/lib/httpApi.js
+++ b/lib/httpApi.js
@@ -31,13 +31,39 @@ module.exports = class HttpApi extends SimpleClass {
   }
 
   async getSASToken(deviceIDHomey) {
+    const cachedToken = this.homey.settings.get(Constants.SettingSasToken);
+    const cachedExpiry = this.homey.settings.get(Constants.SettingSasTokenExpiry);
+
+    // reuse the cached token as long as it isn't expired yet, to avoid
+    // hitting the RegisterMobileDevice endpoint too often (causes 429s)
+    if (cachedToken && cachedExpiry && Date.now() < cachedExpiry) {
+      this.log('SAS token: cache hit, reusing existing token');
+      return cachedToken;
+    }
+
     const url = this.getUrl(Constants.REGISTER_MOBILE_DEVICE);
     const data = await this.doPostRequest(url, {
       Username: this.username.trimEnd(),
       DeviceID: deviceIDHomey,
       DeviceType: '1',
-    });
-    return data.ResObj.SasToken;
+    }, true, { 'Device-ID': deviceIDHomey });
+    const sasToken = data.ResObj.SasToken;
+    this.log('SAS token: fetched and cached a new token');
+
+    this.homey.settings.set(Constants.SettingSasToken, sasToken);
+    this.homey.settings.set(
+      Constants.SettingSasTokenExpiry,
+      this.parseSasTokenExpiry(sasToken),
+    );
+
+    return sasToken;
+  }
+
+  parseSasTokenExpiry(sasToken) {
+    const match = sasToken.match(/se=(\d+)/);
+    // 'se' is the SAS token expiry as a unix timestamp (seconds); fall back
+    // to 1 hour from now if it can't be parsed
+    return match ? parseInt(match[1], 10) * 1000 : Date.now() + 60 * 60 * 1000;
   }
 
   async getACs() {
@@ -65,13 +91,14 @@ module.exports = class HttpApi extends SimpleClass {
     return acs;
   }
 
-  async login(username, password) {
+  async login(username, password, deviceId) {
     const url = this.getUrl(Constants.LOGIN_PATH);
     const json = {
       Username: username,
       Password: password,
+      BrandId: Constants.BRAND_ID,
     };
-   const data = await this.doPostRequest(url, json, false);
+   const data = await this.doPostRequest(url, json, false, { 'Device-ID': deviceId });
 
     this.token_information = data.ResObj;
     this.homey.settings.set(
@@ -130,7 +157,7 @@ module.exports = class HttpApi extends SimpleClass {
     }
   }
 
-  async doPostRequest(url, json, checkAuth = true ) {
+  async doPostRequest(url, json, checkAuth = true, extraHeaders = {} ) {
     if (checkAuth && (!this.header || !this.header.Authorization)) {
       throw new Error('Authorization header is missing');
     }
@@ -140,10 +167,12 @@ module.exports = class HttpApi extends SimpleClass {
       params: this.params,
       data: json,
     };
-    
-    // Add headers only if checkAuth is true
+
+    // Add the auth header only if checkAuth is true, but always send any extraHeaders
     if (checkAuth) {
-      config.headers = this.header;
+      config.headers = { ...this.header, ...extraHeaders };
+    } else if (Object.keys(extraHeaders).length) {
+      config.headers = extraHeaders;
     }
 
     // execute the request


### PR DESCRIPTION
## Problem
The app requested a brand new SAS token from Toshiba on every Homey restart (e.g. a nightly reboot), even when the previous one was still valid. Toshiba's cloud rate-limits repeated device registrations, causing persistent 429 errors.

## Solution
- Cache the SAS token and its expiry (parsed from the token's `se` field) in settings; only request a new one once it actually expires
- `initializeAmqp` now retries with exponential backoff (1-16 min) instead of failing hard
- Added the `Device-ID` header and `BrandId` field that the official Toshiba app sends on login and device registration, which this app was missing (found by sniffing and comparing the official app's network traffic)
- Added logging for login attempts, pairing sessions, and SAS token cache hits/misses, to make future issues easier to diagnose

Tested by running both direct Toshiba API calls and the full pairing flow via `homey app run` on a Homey Pro.