### PR TITLE
Fix app crash on AMQP auth failure and unrecoverable API 401/403s

### DIFF
--- a/drivers/ac/driver.js
+++ b/drivers/ac/driver.js
@@ -32,6 +32,30 @@ class ACDriver extends Driver {
     this.energyConsumption = new EnergyConsumption(this);
 
     this.initEnergyTimer();
+    this.initStatusPolling();
+  }
+
+  // Toshiba only pushes AMQP status/temperature updates sporadically (their
+  // own admission - see GitHub issue #56) and sometimes not at all for a
+  // freshly paired device (issues #90, #95). Poll GetConsumerACMapping as a
+  // fallback so status isn't solely dependent on that push arriving - one
+  // call covers every device, so this doesn't add much extra API load.
+  initStatusPolling() {
+    this.statusPollTimerId = this.homey.setInterval(async () => {
+      const acs = await this.httpAPI.getACs().catch(error => {
+        this.error(`Status poll failed: ${error.message}`);
+        return null;
+      });
+      if (!acs) return;
+
+      const devices = this.getDevices();
+      for (const ac of acs) {
+        const device = devices.find(d => d.getData().DeviceUniqueID === ac.data.DeviceUniqueID);
+        if (device && ac.store.state) {
+          device.updateState(ac.store.state);
+        }
+      }
+    }, 5 * 60 * 1000);
   }
 
   async initEnergyTimer() {

--- a/drivers/ac/driver.js
+++ b/drivers/ac/driver.js
@@ -109,5 +109,24 @@ class ACDriver extends Driver {
     await this.amqpAPI.sendMessage(message);
   }
 
+  onAmqpError(err) {
+    this.error(`AMQP client error: ${err.message}`);
+
+    // debounce: an unhealthy connection can emit several error events in a
+    // row, don't fire off a reconnect (and a fresh token request) for each
+    const now = Date.now();
+    if (this.lastAmqpErrorAt && now - this.lastAmqpErrorAt < 60 * 1000) {
+      return;
+    }
+    this.lastAmqpErrorAt = now;
+
+    // the cached SAS token may have been rejected by Azure even though it
+    // hadn't expired yet per our locally parsed expiry - drop it so the
+    // reconnect fetches a fresh one instead of retrying with the same token
+    this.homey.settings.unset(Constants.SettingSasToken);
+    this.homey.settings.unset(Constants.SettingSasTokenExpiry);
+    this.initializeAmqp();
+  }
+
 }
 module.exports = ACDriver;

--- a/lib/amqpApi.js
+++ b/lib/amqpApi.js
@@ -26,12 +26,23 @@ module.exports = class AmqpApi extends SimpleClass {
 
     // fromSharedAccessSignature must specify a transport constructor, coming from any transport package.
     this.client = Client.fromSharedAccessSignature(sasToken, Protocol);
+    this.client.on('error', err => this.Driver.onAmqpError(err));
     this.createStatusUpdateHandler();
     return this;
   }
 
   setToken(sasToken) {
     this.sasToken = sasToken;
+
+    // push the new token onto the live connection - without this the
+    // client keeps using the (rejected) token it was constructed with
+    if (this.client) {
+      this.client.updateSharedAccessSignature(sasToken, err => {
+        if (err) {
+          this.Driver.homey.app.logInformation('AMQP updateSharedAccessSignature', `error: ${err.toString()}`);
+        }
+      });
+    }
   }
 
   convertHexToDecimal(value) {

--- a/lib/httpApi.js
+++ b/lib/httpApi.js
@@ -20,6 +20,12 @@ module.exports = class HttpApi extends SimpleClass {
     return this;
   }
 
+  // this.log()/this.error() on a plain SimpleClass instance are never
+  // surfaced in the Homey app log - route through the app's logger instead
+  logInfo(message) {
+    this.homey.app.logInformation('HttpApi', message);
+  }
+
   async getACStatus(deviceId) {
     const url = this.getUrl(Constants.STATUS_PATH);
     const params = {
@@ -37,7 +43,7 @@ module.exports = class HttpApi extends SimpleClass {
     // reuse the cached token as long as it isn't expired yet, to avoid
     // hitting the RegisterMobileDevice endpoint too often (causes 429s)
     if (cachedToken && cachedExpiry && Date.now() < cachedExpiry) {
-      this.log('SAS token: cache hit, reusing existing token');
+      this.logInfo('SAS token: cache hit, reusing existing token');
       return cachedToken;
     }
 
@@ -48,7 +54,7 @@ module.exports = class HttpApi extends SimpleClass {
       DeviceType: '1',
     }, true, { 'Device-ID': deviceIDHomey });
     const sasToken = data.ResObj.SasToken;
-    this.log('SAS token: fetched and cached a new token');
+    this.logInfo('SAS token: fetched and cached a new token');
 
     this.homey.settings.set(Constants.SettingSasToken, sasToken);
     this.homey.settings.set(
@@ -145,7 +151,7 @@ module.exports = class HttpApi extends SimpleClass {
     };
 
     try {
-      const { data } = await http.axios(config);
+      const { data } = await this.executeWithReauth(config, true);
       // status 200 but error from Toshiba
       if (data && !data.IsSuccess) {
         throw new Error(data.Message);
@@ -177,7 +183,7 @@ module.exports = class HttpApi extends SimpleClass {
 
     // execute the request
     try {
-      const { data } = await http.axios(config);
+      const { data } = await this.executeWithReauth(config, checkAuth);
       // status 200 but Homey didn't manage to start/stop
       if (data && data.message_type === 'Error') {
         throw new Error(data.message);
@@ -191,6 +197,43 @@ module.exports = class HttpApi extends SimpleClass {
       const er = new Error(ex);
       return Promise.reject(er);
     }
+  }
+
+  // the Toshiba API access token isn't refreshed anywhere else, so a 401/403
+  // means it expired; re-login with the stored credentials and retry once
+  // instead of leaving every subsequent request broken until the app restarts
+  async executeWithReauth(config, allowReauth) {
+    try {
+      return await http.axios(config);
+    } catch (ex) {
+      const status = ex.response && ex.response.status;
+      if (allowReauth && (status === 401 || status === 403) && this.username && this.password) {
+        this.logInfo(`Request failed with ${status}, re-authenticating and retrying`);
+        await this.reLogin();
+        config.headers = { ...config.headers, Authorization: this.header.Authorization };
+        return http.axios(config);
+      }
+      throw ex;
+    }
+  }
+
+  // several requests can hit a 401/403 around the same time (e.g. one per
+  // device); de-dupe so they share a single login instead of racing each
+  // other, which can invalidate the session the other one just obtained
+  async reLogin() {
+    if (!this.reLoginPromise) {
+      const deviceId = this.homey.settings.get(Constants.SettingDriverDeviceID);
+      this.reLoginPromise = this.login(this.username, this.password, deviceId)
+        .then(() => this.logInfo('Re-authentication successful'))
+        .catch(err => {
+          this.logInfo(`Re-authentication failed: ${err.message || err}`);
+          throw err;
+        })
+        .finally(() => {
+          this.reLoginPromise = null;
+        });
+    }
+    return this.reLoginPromise;
   }
 
   getUrl(suburl) {


### PR DESCRIPTION
## Summary
- The AMQP client (`azure-iot-device`) emits an `error` event when the SAS token is rejected. Without a listener, Node treats this as an uncaught exception and kills the app process - this is what was crashing the app on Homey Pro. Added a listener that clears the cached token and reconnects instead.
- `setToken()` only updated a local field and never pushed the new token onto the live connection. Fixed to call `updateSharedAccessSignature()` so reconnects actually take effect.
- The main API access token had no refresh path: once it expired, every authenticated request failed with 401/403 forever (seen repeatedly in energy-consumption polling). Now re-logs in with the stored credentials and retries once, de-duped so concurrent failures share a single login instead of racing each other.
- Routed `HttpApi`'s logging through `homey.app.logInformation`, since `this.log()` on a plain `SimpleClass` instance never reached the app log - silently defeating the diagnostic logging added in the previous SAS-token fix.
- Temperature/status previously updated *only* via sporadic AMQP heartbeat pushes from Toshiba's cloud - sporadic by Toshiba's own admission (#56), and sometimes never arriving at all for a freshly paired device (#90, #95). Added a 5-minute `GetConsumerACMapping` poll as a fallback, feeding into the existing `updateState()` path. One call covers every device, so it doesn't meaningfully add to API load.

## Test plan
- [x] `homey app validate` (publish level)
- [x] Live-tested in `homey app run` dev mode against a real Homey Pro: reproduced the original `UnauthorizedError` crash, confirmed the app now logs and recovers instead of crashing
- [x] Reproduced a live 401/403 during energy-consumption polling, confirmed a single de-duped re-login and successful retry, with no further errors
- [x] Reproduced a device stuck on `null` temperature (matching a live user report) and confirmed it picks up the correct value after one status-poll cycle; confirmed other devices' stale cached values also refresh to current readings

🤖 Generated with [Claude Code](https://claude.com/claude-code)