### PR TITLE
Fix status poll overwriting recently commanded AC state

### DIFF
--- a/drivers/ac/device.js
+++ b/drivers/ac/device.js
@@ -222,7 +222,20 @@ class ACDevice extends Device {
       error => logError(this, error),
     );
     await this.setStoreValue(Constants.StoredValueState, state).catch(error => logError(this, error));
+    this.lastLocalCommandAt = Date.now();
     this.driver.amqpAPI.sendMessage(state, this.getData().DeviceUniqueID);
+  }
+
+  // Toshiba's cloud-side status snapshot (GetConsumerACMapping, used by the
+  // driver's status poll) can briefly lag behind a command we just sent -
+  // the AC and Toshiba's own backend both need a moment to catch up. Applying
+  // a poll result from within that window would overwrite the state we just
+  // set with stale data, e.g. turning a device that was just switched off
+  // back on in Homey. Give locally issued commands a grace period to
+  // propagate before trusting the poll again.
+  recentlyCommandedLocally() {
+    const graceMs = 2 * 60 * 1000;
+    return !!this.lastLocalCommandAt && (Date.now() - this.lastLocalCommandAt) < graceMs;
   }
 
   async setEnergyIntervalTimer() {

--- a/drivers/ac/driver.js
+++ b/drivers/ac/driver.js
@@ -49,12 +49,22 @@ class ACDriver extends Driver {
       if (!acs) return;
 
       const devices = this.getDevices();
+      const updated = [];
+      const skipped = [];
       for (const ac of acs) {
         const device = devices.find(d => d.getData().DeviceUniqueID === ac.data.DeviceUniqueID);
-        if (device && ac.store.state) {
-          device.updateState(ac.store.state);
+        if (!device || !ac.store.state) continue;
+        // Skip devices we commanded locally very recently: Toshiba's cloud
+        // snapshot can still be stale at this point and would otherwise
+        // overwrite the state we just set (e.g. turning it back on).
+        if (device.recentlyCommandedLocally()) {
+          skipped.push(device.getName());
+          continue;
         }
+        device.updateState(ac.store.state);
+        updated.push(device.getName());
       }
+      this.log(`Status poll: updated [${updated.join(', ')}], skipped (recently commanded) [${skipped.join(', ')}]`);
     }, 5 * 60 * 1000);
   }
 


### PR DESCRIPTION
## Problem
The status poll added in v4.2.0 (`initStatusPolling`) can race with a locally issued on/off or mode command: Toshiba's cloud-side snapshot (`GetConsumerACMapping`) briefly lags behind after a command, so a poll landing in that window overwrites the just-set state with stale data — matching community reports of AC units turning back on right after being switched off (v4.2.0/4.2.1).

## Solution
- Track when a device was last commanded locally
- Skip applying poll results to that device for a 2-minute grace period, giving the command time to propagate through Toshiba's backend before trusting the poll again
- Log which devices were updated vs skipped each poll cycle, so a future report can be diagnosed from the app logs directly instead of guessed at from code