### PR TITLE
Fix app crash on AMQP send errors (malformed tagged template)

### DIFF
--- a/lib/amqpApi.js
+++ b/lib/amqpApi.js
@@ -9,7 +9,7 @@ const Constants = require('./constants');
 // Helper function to print results in the console
 function printResultFor(op, homey, deviceUniqueID, message ) {
   return function printResult(err, res) {
-    if (err) homey.app.logInformation(`AMQP sendMessage`, `Send``${op} error: ${err.toString()}`);
+    if (err) homey.app.logInformation(`AMQP sendMessage`, `Send ${op} error: ${err.toString()}`);
     else{
       homey.app.logInformation( `AMQP sendMessage`, `Send: ${deviceUniqueID} ${message}`);
     }


### PR DESCRIPTION
## Problem
`printResultFor`'s error branch in `lib/amqpApi.js` had a typo:

```js
`Send``${op} error: ${err.toString()}`
```

Two adjacent template literals with no operator between them parse as a tagged template call - the string `"Send"` gets invoked as the tag function, throwing `TypeError: "Send" is not a function`. Confirmed against a live crash report (build #56/v4.2.3, 13 crashes) with this exact stack trace.

This crashed the whole app on every AMQP send failure, before the already-optimistically-set local on/off state could be corrected or retried - matching community reports of the AC appearing off in both Homey and the Toshiba app while staying physically on. It also explains why the poll-race fix (#99) didn't fully resolve those reports: a crash wipes the in-memory grace-period tracking that fix relies on.

## Solution
Fix the typo so the error is logged instead of crashing the app.

Verified by simulating the exact error callback path locally - confirmed it logs correctly instead of throwing.